### PR TITLE
Update Index Site Title

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -9,7 +9,7 @@
     <script type="text/javascript">
       window.location.href = 'docs/about_dbt_labs';
     </script>
-    <title>Your Site Title Here</title>
+    <title>dbt Labs Handbook</title>
   </head>
   <body>
     If you are not redirected automatically, follow this


### PR DESCRIPTION
I tried to share a link to the company values and LinkedIn previewed the url showing the site title to be "Your Site Title Here" as seen in the screenshot below.

<img width="281" alt="Screenshot 2023-11-21 at 11 22 26" src="https://github.com/dbt-labs/handbook/assets/38038720/b857d9e8-4adb-4481-bbc0-0a3db54e6b21">

I looked through the code and the only reference to that string was in this file. I'm not sure if this is the exact title it should be, but it seems better than the generic docusaurus template. Please let me know if you want it to be something else.  