### PR TITLE
Update url paths to use old route

### DIFF
--- a/website/docs/about_dbt_labs.md
+++ b/website/docs/about_dbt_labs.md
@@ -2,7 +2,7 @@
 id: about_dbt_labs
 title: The dbt Labs Employee Handbook
 sidebar_label: About dbt Labs
-slug: /
+slug: /about_dbt_labs
 ---
 
 | Maintained by |

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,7 +45,7 @@ const siteSettings = {
       title: "Handbook",
       logo: {
         src: "img/dbt-labs-light.svg",
-        href: "/docs",
+        href: "/docs/about_dbt_labs",
       },
       items: [],
     },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,7 +19,7 @@ const siteSettings = {
           showLastUpdateTime: true,
           path: "./docs",
           sidebarPath: "./sidebars.json",
-          routeBasePath: "/docs/about_dbt_labs",
+          routeBasePath: "/docs",
           breadcrumbs: false,
           showLastUpdateTime: false,
           showLastUpdateAuthor: false,
@@ -45,7 +45,7 @@ const siteSettings = {
       title: "Handbook",
       logo: {
         src: "img/dbt-labs-light.svg",
-        href: "/docs/about_dbt_labs",
+        href: "/docs",
       },
       items: [],
     },

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,9 @@
+{
+    "redirects": [
+        {
+            "source": "/",
+            "destination": "/docs",
+            "permanent": true
+        }
+    ]
+}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2,7 +2,12 @@
     "redirects": [
         {
             "source": "/",
-            "destination": "/docs",
+            "destination": "/docs/about_dbt_labs",
+            "permanent": true
+        },
+        {
+            "source": "/docs",
+            "destination": "/docs/about_dbt_labs",
             "permanent": true
         }
     ]


### PR DESCRIPTION
After the PR that contained the docusaurs upgrade was merged Leigh noticed the URLs that were linked in notion were broken.
e.g.
https://handbook.getdbt.com/docs/benefits#healthcare-benefits-us
https://handbook.getdbt.com/docs/time_off

This PR updates the `routeBasePath` to use what we previously had making the links work again.
https://handbook-getdbt-com-git-update-url-paths-dbt-labs.vercel.app/docs/benefits#healthcare-benefits-us
https://handbook-getdbt-com-git-update-url-paths-dbt-labs.vercel.app/docs/time_off