### PR TITLE
update broken link

### DIFF
--- a/website/docs/time_off.md
+++ b/website/docs/time_off.md
@@ -59,7 +59,7 @@ When in doubt, please discuss with your manager about your plans.
 
 Note that because, in the United States, your time off is not accrued, you will not be paid out for any unused time offered under this policy when your employment with dbt Labs ends.
 
-For international employees, see [below]([#-international-considerations-for-accrued-time-and-pay-out-upon-termination-with-the-company) for respective details.
+For international employees, see [below](#international-considerations-for-accrued-time-and-pay-out-upon-termination-with-the-company) for respective details.
 
 #### 💪 Best practices for being out of the office 
 

--- a/website/docs/time_off.md
+++ b/website/docs/time_off.md
@@ -62,7 +62,7 @@ Note that because, in the United States, your time off is not accrued, you will 
 For international employees, see [below](#international-considerations-for-accrued-time-and-pay-out-upon-termination-with-the-company) for respective details.
 
 #### 💪 Best practices for being out of the office 
-
+ 
 1️⃣ We recommend that after your time off request has been approved, to note you will be “Out of Office” on your Google Calendar (and make this event public so people can see).
 
 Google Calendar also has an “Out of Office” feature where they can auto-decline any event that is scheduled during the period you are out. This may be helpful for you to set up!


### PR DESCRIPTION
this pr fixes a link typo on the same page as if someone clicked on the 'below' link, it would take the user to a 'page not found. it removes the extra `[` and `-` as well.