### PR TITLE
Update benefits link to more generic one

### DIFF
--- a/website/docs/benefits.md
+++ b/website/docs/benefits.md
@@ -111,7 +111,7 @@ Learn how to ask questions through our partner Newfront Answers [here](https://w
 
 ### Medical Plans (US)
 
-Learn more about our medical plans [here](https://app.strivebenefits.com/dbt/2022-2023-medical?country=us).
+Learn more about our medical plans [here](https://app.strivebenefits.com/dbt).
 
 ### Disability and Life Insurance (US)
 We provide long term and short term disability as well as life insurance coverage to all US-based employees at no cost. Voluntary, additional, life insurance coverage for employees and dependants is available at the expense of the employee. 


### PR DESCRIPTION
The previous link is broken and goes to a 404:

<img width="1255" alt="Screenshot 2024-11-18 at 4 31 11 PM" src="https://github.com/user-attachments/assets/f76414d8-47e4-4754-a8d7-fe4b6ab423c6">

This updates the link to a more generic one, from which you can get to the benefits. Alternatively we could update to the 2024 medical one (https://app.strivebenefits.com/dbt/2024-medical?country=us)